### PR TITLE
Add main menu page for games and admin features

### DIFF
--- a/main.py
+++ b/main.py
@@ -69,7 +69,7 @@ def get_word_list_for_game(game_mode, word_count):
 #   Define a simple route
 @app.route("/")
 def home():
-    return "Flask App with MySQL is Running!"
+    return render_template("menu.html")
 
 @app.route("/show-dictionary")
 def show_dictionary():

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -65,3 +65,28 @@ img.flag {
 
     width: 50%;
 }
+
+.menu {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    font-family: Trebuchet MS;
+}
+
+.menu ul {
+    list-style-type: none;
+    padding: 0;
+}
+
+.menu li {
+    margin: 5px 0;
+}
+
+.menu a {
+    text-decoration: none;
+    color: #333;
+}
+
+.menu a:hover {
+    text-decoration: underline;
+}

--- a/templates/menu.html
+++ b/templates/menu.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
+    <title>Learning Italian - Menu</title>
+</head>
+<body>
+    <h1>Learning Italian - Menu</h1>
+    <nav class="menu">
+        <h2>Games</h2>
+        <ul>
+            <li><a href="{{ url_for('vocabulary_test', game_mode='random', word_count=10) }}">Vocabulary Test (Random 10 words)</a></li>
+            <li><a href="{{ url_for('flash_card_game', game_mode='random', game_difficulty='easy') }}">Flash Card Game (Easy)</a></li>
+        </ul>
+        <h2>Admin</h2>
+        <ul>
+            <li><a href="{{ url_for('import_words') }}">Import Words</a></li>
+            <li><a href="{{ url_for('show_dictionary') }}">Show Dictionary</a></li>
+        </ul>
+    </nav>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add menu template that links to vocabulary test, flash card game, word import, and dictionary views
- Update home route to render the new menu
- Add basic styling for menu layout and links

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5edc2362c8322874015bf6015ef38