### PR TITLE
feat: add game option menus and back navigation

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ import pandas
 import logging
 logging.basicConfig(level=logging.INFO)
 
-from flask import Flask, render_template, request
+from flask import Flask, render_template, request, redirect, url_for
 from dotenv import load_dotenv
 from db.connection import Session, init_db
 from repo.dictionary_crud import DictionaryRepository
@@ -16,6 +16,12 @@ FLASH_CARD_GAME_DIFFICULTY_SETTINGS = {
     "easy": {"x": 4, "y": 3},
     "medium": {"x": 5, "y": 4},
     "hard": {"x": 6, "y": 5}
+}
+
+VOCABULARY_TEST_DIFFICULTY_SETTINGS = {
+    "easy": 10,
+    "medium": 20,
+    "hard": 30,
 }
 
 #FLASH_CARD_GAME_SETTINGS = {
@@ -65,6 +71,35 @@ def get_word_list_for_game(game_mode, word_count):
 @app.route("/")
 def home():
     return render_template("menu.html")
+
+
+@app.route("/vocabulary-test-options", methods=["GET", "POST"])
+def vocabulary_test_options():
+    if request.method == "POST":
+        mode = request.form.get("mode")
+        difficulty = request.form.get("difficulty")
+        word_count = VOCABULARY_TEST_DIFFICULTY_SETTINGS[difficulty]
+        return redirect(url_for("vocabulary_test", game_mode=mode, word_count=word_count))
+    return render_template(
+        "vocabulary_test_options.html",
+        game_modes=game_modes,
+        difficulties=VOCABULARY_TEST_DIFFICULTY_SETTINGS.keys(),
+    )
+
+
+@app.route("/flash-card-options", methods=["GET", "POST"])
+def flash_card_options():
+    if request.method == "POST":
+        mode = request.form.get("mode")
+        difficulty = request.form.get("difficulty")
+        return redirect(
+            url_for("flash_card_game", game_mode=mode, game_difficulty=difficulty)
+        )
+    return render_template(
+        "flash_card_options.html",
+        game_modes=game_modes,
+        difficulties=FLASH_CARD_GAME_DIFFICULTY_SETTINGS.keys(),
+    )
 
 @app.route("/show-dictionary")
 def show_dictionary():

--- a/templates/flash_card_game.html
+++ b/templates/flash_card_game.html
@@ -26,5 +26,6 @@
             </div>
         </div>
     </div>
+    <a href="{{ url_for('home') }}">Back to Menu</a>
 </body>
 </html>

--- a/templates/flash_card_options.html
+++ b/templates/flash_card_options.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
+    <title>Flash Card Game Options</title>
+</head>
+<body>
+    <h1>Flash Card Game - Options</h1>
+    <form method="post">
+        <label for="mode">Mode:</label>
+        <select id="mode" name="mode">
+            {% for mode in game_modes %}
+            <option value="{{ mode }}">{{ mode }}</option>
+            {% endfor %}
+        </select>
+        <label for="difficulty">Difficulty:</label>
+        <select id="difficulty" name="difficulty">
+            {% for diff in difficulties %}
+            <option value="{{ diff }}">{{ diff }}</option>
+            {% endfor %}
+        </select>
+        <button type="submit">Start</button>
+    </form>
+    <a href="{{ url_for('home') }}">Back to Menu</a>
+</body>
+</html>
+

--- a/templates/menu.html
+++ b/templates/menu.html
@@ -11,8 +11,8 @@
     <nav class="menu">
         <h2>Games</h2>
         <ul>
-            <li><a href="{{ url_for('vocabulary_test', game_mode='random', word_count=10) }}">Vocabulary Test (Random 10 words)</a></li>
-            <li><a href="{{ url_for('flash_card_game', game_mode='random', game_difficulty='easy') }}">Flash Card Game (Easy)</a></li>
+            <li><a href="{{ url_for('vocabulary_test_options') }}">Vocabulary Test</a></li>
+            <li><a href="{{ url_for('flash_card_options') }}">Flash Card Game</a></li>
         </ul>
         <h2>Admin</h2>
         <ul>

--- a/templates/vocabulary_test.html
+++ b/templates/vocabulary_test.html
@@ -24,5 +24,6 @@
             <span class="test-word" data-id="{{ word.id }}" data-italian="{{ word.italian }}">{{ word.english }}</span>
         {% endfor %}
     </div>
+    <a href="{{ url_for('home') }}">Back to Menu</a>
 </body>
 </html>

--- a/templates/vocabulary_test_options.html
+++ b/templates/vocabulary_test_options.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
+    <title>Vocabulary Test Options</title>
+</head>
+<body>
+    <h1>Vocabulary Test - Options</h1>
+    <form method="post">
+        <label for="mode">Mode:</label>
+        <select id="mode" name="mode">
+            {% for mode in game_modes %}
+            <option value="{{ mode }}">{{ mode }}</option>
+            {% endfor %}
+        </select>
+        <label for="difficulty">Difficulty:</label>
+        <select id="difficulty" name="difficulty">
+            {% for diff in difficulties %}
+            <option value="{{ diff }}">{{ diff }}</option>
+            {% endfor %}
+        </select>
+        <button type="submit">Start</button>
+    </form>
+    <a href="{{ url_for('home') }}">Back to Menu</a>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- expand main menu to choose between vocabulary test and flash card game
- add option pages to select game mode and difficulty
- provide back-to-menu buttons on game pages

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`
- `flake8` *(fails: style violations in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f3baca68832288220374191f1b6f