### PR TITLE
Add back-to-menu buttons to game pages

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -90,3 +90,20 @@ img.flag {
 .menu a:hover {
     text-decoration: underline;
 }
+
+.back-to-menu {
+    position: absolute;
+    top: 20px;
+    left: 20px;
+    padding: 10px 15px;
+    background-color: #f0f0f0;
+    border: 1px solid #333;
+    border-radius: 5px;
+    text-decoration: none;
+    color: #333;
+    font-family: Trebuchet MS;
+}
+
+.back-to-menu:hover {
+    background-color: #e0e0e0;
+}

--- a/templates/flash_card_game.html
+++ b/templates/flash_card_game.html
@@ -8,6 +8,7 @@
     <title>Document</title>
 </head>
 <body>
+    <a href="{{ url_for('home') }}" class="back-to-menu">Back to Menu</a>
     <div class="main">
         <div class="flash-card-game-wrapper">
             <div class="flash-card-game-main" style="grid-template-columns:repeat({{ x_dimension }}, 1fr); grid-template-rows:repeat({{ y_dimension }}, 1fr)">
@@ -26,6 +27,5 @@
             </div>
         </div>
     </div>
-    <a href="{{ url_for('home') }}">Back to Menu</a>
 </body>
 </html>

--- a/templates/vocabulary_test.html
+++ b/templates/vocabulary_test.html
@@ -8,6 +8,7 @@
     <title>Italian vocabulary test</title>
 </head>
 <body>
+    <a href="{{ url_for('home') }}" class="back-to-menu">Back to Menu</a>
     <div class="vocabulary-test main">
         <div class="result-column correct"></div>
         <div class="game-field">
@@ -24,6 +25,5 @@
             <span class="test-word" data-id="{{ word.id }}" data-italian="{{ word.italian }}">{{ word.english }}</span>
         {% endfor %}
     </div>
-    <a href="{{ url_for('home') }}">Back to Menu</a>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add back-to-menu link at top of flash card and vocabulary test pages
- Style navigation link as button for consistent look

## Testing
- `pytest`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a5f6530890832285914060f9bf62fb