### PR TITLE
Center Back to Menu buttons

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -92,9 +92,10 @@ img.flag {
 }
 
 .back-to-menu {
-    position: absolute;
-    top: 20px;
-    left: 20px;
+    position: fixed;
+    bottom: 20px;
+    left: 50%;
+    transform: translateX(-50%);
     padding: 10px 15px;
     background-color: #f0f0f0;
     border: 1px solid #333;
@@ -102,6 +103,7 @@ img.flag {
     text-decoration: none;
     color: #333;
     font-family: Trebuchet MS;
+    cursor: pointer;
 }
 
 .back-to-menu:hover {

--- a/templates/flash_card_game.html
+++ b/templates/flash_card_game.html
@@ -8,7 +8,6 @@
     <title>Document</title>
 </head>
 <body>
-    <a href="{{ url_for('home') }}" class="back-to-menu">Back to Menu</a>
     <div class="main">
         <div class="flash-card-game-wrapper">
             <div class="flash-card-game-main" style="grid-template-columns:repeat({{ x_dimension }}, 1fr); grid-template-rows:repeat({{ y_dimension }}, 1fr)">
@@ -27,5 +26,6 @@
             </div>
         </div>
     </div>
+    <button class="back-to-menu" onclick="window.location.href='{{ url_for('home') }}'">Back to Menu</button>
 </body>
 </html>

--- a/templates/flash_card_options.html
+++ b/templates/flash_card_options.html
@@ -23,7 +23,7 @@
         </select>
         <button type="submit">Start</button>
     </form>
-    <a href="{{ url_for('home') }}">Back to Menu</a>
+    <button class="back-to-menu" onclick="window.location.href='{{ url_for('home') }}'">Back to Menu</button>
 </body>
 </html>
 

--- a/templates/vocabulary_test.html
+++ b/templates/vocabulary_test.html
@@ -8,7 +8,6 @@
     <title>Italian vocabulary test</title>
 </head>
 <body>
-    <a href="{{ url_for('home') }}" class="back-to-menu">Back to Menu</a>
     <div class="vocabulary-test main">
         <div class="result-column correct"></div>
         <div class="game-field">
@@ -25,5 +24,6 @@
             <span class="test-word" data-id="{{ word.id }}" data-italian="{{ word.italian }}">{{ word.english }}</span>
         {% endfor %}
     </div>
+    <button class="back-to-menu" onclick="window.location.href='{{ url_for('home') }}'">Back to Menu</button>
 </body>
 </html>

--- a/templates/vocabulary_test_options.html
+++ b/templates/vocabulary_test_options.html
@@ -23,7 +23,7 @@
         </select>
         <button type="submit">Start</button>
     </form>
-    <a href="{{ url_for('home') }}">Back to Menu</a>
+    <button class="back-to-menu" onclick="window.location.href='{{ url_for('home') }}'">Back to Menu</button>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- Convert all "Back to Menu" links into buttons using shared `.back-to-menu` class.
- Update styles to position the button centered at the bottom of the page across views.

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a5f84c23488322990868d099620c44