### PR TITLE
Display dictionary as table with practice stats

### DIFF
--- a/main.py
+++ b/main.py
@@ -106,12 +106,7 @@ def show_dictionary():
     dict_repo = DictionaryRepository(Session())
     word_list = dict_repo.get_all_words()
 
-    words = ""
-
-    for word in word_list:
-        words += ( str(word) + "\n" )
-
-    return words
+    return render_template("show_dictionary.html", word_list=word_list)
 
 @app.route("/vocabulary-test/<string:game_mode>/<int:word_count>")
 def vocabulary_test(game_mode, word_count):

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -109,3 +109,20 @@ img.flag {
 .back-to-menu:hover {
     background-color: #e0e0e0;
 }
+
+.dictionary-table {
+    border-collapse: collapse;
+    width: 100%;
+    font-family: Trebuchet MS;
+}
+
+.dictionary-table th,
+.dictionary-table td {
+    border: 1px solid #333;
+    padding: 8px;
+    text-align: left;
+}
+
+.dictionary-table th {
+    background-color: #f0f0f0;
+}

--- a/templates/show_dictionary.html
+++ b/templates/show_dictionary.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
+    <title>Dictionary</title>
+</head>
+<body>
+    <div class="main">
+        <table class="dictionary-table">
+            <thead>
+                <tr>
+                    <th>Word No.</th>
+                    <th>English</th>
+                    <th>Italian</th>
+                    <th>Last Practiced</th>
+                    <th>Practiced Count</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for word in word_list %}
+                <tr>
+                    <td>{{ loop.index }}</td>
+                    <td>{{ word.english }}</td>
+                    <td>{{ word.italian }}</td>
+                    <td>{{ word.practice_history.last_practiced_on if word.practice_history else '' }}</td>
+                    <td>{{ word.practice_history.practiced_counter if word.practice_history else 0 }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    <button class="back-to-menu" onclick="window.location.href='{{ url_for('home') }}'">Back to Menu</button>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- Render `/show-dictionary` route using a template
- Add `show_dictionary.html` to display word list with last practiced time and practice count
- Add CSS styles for dictionary table

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5f9ec20d88322b4a3a0d30515c4cd