### PR TITLE
Enhance main menu styling

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1,3 +1,8 @@
+body {
+    font-family: Trebuchet MS;
+    margin: 0;
+}
+
 .flash-card-game-wrapper {
     display: flex;
     justify-content: center; /* center horizontally */
@@ -66,29 +71,38 @@ img.flag {
     width: 50%;
 }
 
+.menu-wrapper {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+}
+
 .menu {
     display: flex;
     flex-direction: column;
+    align-items: center;
+    gap: 30px;
+}
+
+.menu .section {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
     gap: 10px;
-    font-family: Trebuchet MS;
 }
 
-.menu ul {
-    list-style-type: none;
-    padding: 0;
+.menu button {
+    padding: 10px 20px;
+    background-color: #D0D4CA;
+    border: 2px solid #333;
+    border-radius: 5px;
+    cursor: pointer;
+    font-weight: bold;
 }
 
-.menu li {
-    margin: 5px 0;
-}
-
-.menu a {
-    text-decoration: none;
-    color: #333;
-}
-
-.menu a:hover {
-    text-decoration: underline;
+.menu button:hover {
+    background-color: #A7D397;
 }
 
 .back-to-menu {

--- a/templates/menu.html
+++ b/templates/menu.html
@@ -7,18 +7,20 @@
     <title>Learning Italian - Menu</title>
 </head>
 <body>
-    <h1>Learning Italian - Menu</h1>
-    <nav class="menu">
-        <h2>Games</h2>
-        <ul>
-            <li><a href="{{ url_for('vocabulary_test_options') }}">Vocabulary Test</a></li>
-            <li><a href="{{ url_for('flash_card_options') }}">Flash Card Game</a></li>
-        </ul>
-        <h2>Admin</h2>
-        <ul>
-            <li><a href="{{ url_for('import_words') }}">Import Words</a></li>
-            <li><a href="{{ url_for('show_dictionary') }}">Show Dictionary</a></li>
-        </ul>
-    </nav>
+    <div class="menu-wrapper">
+        <nav class="menu">
+            <h1>Learning Italian</h1>
+            <div class="section">
+                <h2>Games</h2>
+                <button onclick="window.location.href='{{ url_for('vocabulary_test_options') }}'">Vocabulary Test</button>
+                <button onclick="window.location.href='{{ url_for('flash_card_options') }}'">Flash Card Game</button>
+            </div>
+            <div class="section">
+                <h2>Admin</h2>
+                <button onclick="window.location.href='{{ url_for('import_words') }}'">Import Words</button>
+                <button onclick="window.location.href='{{ url_for('show_dictionary') }}'">Show Dictionary</button>
+            </div>
+        </nav>
+    </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Centered the main menu and replaced list links with navigation buttons.
- Introduced global Trebuchet MS font for consistent typography.
- Styled menu buttons to reflect the flash card game's color scheme.

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a6d1ba3c448322947023df99f8dace