### PR TITLE
Make dictionary columns sortable

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -150,4 +150,17 @@ img.flag {
 
 .dictionary-table th {
     background-color: #f0f0f0;
+    cursor: pointer;
+}
+
+.dictionary-table th:first-child {
+    cursor: default;
+}
+
+.dictionary-table th.sorted-asc::after {
+    content: " \25B2";
+}
+
+.dictionary-table th.sorted-desc::after {
+    content: " \25BC";
 }

--- a/static/js/dictionary.js
+++ b/static/js/dictionary.js
@@ -1,0 +1,42 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const table = document.querySelector('.dictionary-table');
+  if (!table) return;
+
+  const headers = table.querySelectorAll('th');
+
+  headers.forEach((header, index) => {
+    if (index === 0) return; // Skip Word No. column
+    header.addEventListener('click', () => {
+      const type = header.dataset.type || 'string';
+      sortTableByColumn(table, index, type, header);
+    });
+  });
+});
+
+function sortTableByColumn(table, columnIndex, type, header) {
+  const tbody = table.tBodies[0];
+  const rows = Array.from(tbody.querySelectorAll('tr'));
+  const isAscending = !header.classList.contains('sorted-asc');
+  const dir = isAscending ? 1 : -1;
+
+  rows.sort((a, b) => {
+    const aText = a.children[columnIndex].textContent.trim();
+    const bText = b.children[columnIndex].textContent.trim();
+    let compare = 0;
+
+    if (type === 'number') {
+      compare = parseFloat(aText) - parseFloat(bText);
+    } else if (type === 'date') {
+      compare = new Date(aText) - new Date(bText);
+    } else {
+      compare = aText.localeCompare(bText);
+    }
+    return compare * dir;
+  });
+
+  table.querySelectorAll('th').forEach(th => th.classList.remove('sorted-asc', 'sorted-desc'));
+  header.classList.toggle('sorted-asc', isAscending);
+  header.classList.toggle('sorted-desc', !isAscending);
+
+  rows.forEach(row => tbody.appendChild(row));
+}

--- a/templates/show_dictionary.html
+++ b/templates/show_dictionary.html
@@ -12,10 +12,10 @@
             <thead>
                 <tr>
                     <th>Word No.</th>
-                    <th>English</th>
-                    <th>Italian</th>
-                    <th>Last Practiced</th>
-                    <th>Practiced Count</th>
+                    <th data-type="string">English</th>
+                    <th data-type="string">Italian</th>
+                    <th data-type="date">Last Practiced</th>
+                    <th data-type="number">Practiced Count</th>
                 </tr>
             </thead>
             <tbody>
@@ -43,6 +43,7 @@
         </table>
     </div>
     <button class="back-to-menu" onclick="window.location.href='{{ url_for('home') }}'">Back to Menu</button>
+    <script src="{{ url_for('static', filename='js/dictionary.js') }}"></script>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- Add client-side column sorting for dictionary table
- Style sortable headers and show sort direction arrows

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6d57a5f988322b64cb6ac1ecbec0c